### PR TITLE
Add ability to use relative widths

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,14 +1,21 @@
 <html>
   <head>
     <title>Sample App</title>
-    <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
+    <script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/js/materialize.min.js"></script>
+
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   <meta name = "viewport" content = "user-scalable=no, initial-scale=1.0, maximum-scale=1.0, width=device-width">
   <style>
     body {
       background: #dedede;
       overflow: hidden;
+    }
+
+    .options {
+      padding: 1rem;
+      margin-top: 5rem;
     }
   </style>
   </head>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -9,7 +9,8 @@ const style = {
 export default class App extends Component {
   state = {
     openLeft: false,
-    openRight: false
+    openRight: false,
+    relativeWidth: false,
   };
 
   render() {
@@ -22,7 +23,7 @@ export default class App extends Component {
     return (
       <div>
       { !openRight &&
-      <Drawer {...drawerProps} fadeOut={true} open={openLeft} onChange={open => this.setState({ openLeft: open})}>
+      <Drawer {...drawerProps} width={this.state.relativeWidth ? '50%' : 300} fadeOut={true} open={openLeft} onChange={open => this.setState({ openLeft: open})}>
         <div style={{ width: '100%' }}>
           <img src="../media/planurahuette.jpg"/>
         </div>
@@ -31,7 +32,7 @@ export default class App extends Component {
          </div>
       </Drawer> }
       { !openLeft &&
-      <Drawer right={true} {...drawerProps} open={openRight} onChange={open => this.setState({ openRight: open})}>
+      <Drawer right={true} width={this.state.relativeWidth ? '50vw' : 300} {...drawerProps} open={openRight} onChange={open => this.setState({ openRight: open})}>
         {val => {
           var per = val/ 300;
           return <div style={{ backgroundColor: `rgba(0, 184, 212, ${per})`, width: '100%', height: '100%' }} />;
@@ -44,9 +45,9 @@ export default class App extends Component {
           <a href="#" className="brand-logo center">rm-drawer</a>
           <ul className="left">
             <li style={{ cursor: 'pointer', height: '100%' }}>
-            <a style={{ padding: 15}} className='' onClick={()=>this.setState({openLeft:!openLeft, openRight: false})}>
-              <i className="fa fa-bars"></i>
-            </a>
+              <a style={{ padding: 15}} className='' onClick={()=>this.setState({openLeft:!openLeft, openRight: false})}>
+                <i className="fa fa-bars"></i>
+              </a>
             </li>
           </ul>
           <ul className="right">
@@ -59,7 +60,15 @@ export default class App extends Component {
         </div>
       </nav>
       </div>
+      <div className="options">
+        <form>
+          <p>
+            <input type="checkbox" id="relative_width" onChange={()=>this.setState({relativeWidth: !this.state.relativeWidth})}/>
+            <label htmlFor="relative_width">Relative width</label>
+          </p>
+        </form>
       </div>
+    </div>
     );
   }
 }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -11,8 +11,14 @@ export default class App extends Component {
     openLeft: false,
     openRight: false,
     relativeWidth: false,
+    width: 300
   };
 
+  setWidth = (e) => {
+    this.setState({
+      width: Number(e.target.value) || e.target.value),
+    });
+  }
   render() {
     const { openLeft, openRight } = this.state;
     const drawerProps = {
@@ -23,7 +29,7 @@ export default class App extends Component {
     return (
       <div>
       { !openRight &&
-      <Drawer {...drawerProps} width={this.state.relativeWidth ? '50%' : 300} fadeOut={true} open={openLeft} onChange={open => this.setState({ openLeft: open})}>
+      <Drawer {...drawerProps} width={this.state.width} fadeOut={true} open={openLeft} onChange={open => this.setState({ openLeft: open})}>
         <div style={{ width: '100%' }}>
           <img src="../media/planurahuette.jpg"/>
         </div>
@@ -32,7 +38,7 @@ export default class App extends Component {
          </div>
       </Drawer> }
       { !openLeft &&
-      <Drawer right={true} width={this.state.relativeWidth ? '50vw' : 300} {...drawerProps} open={openRight} onChange={open => this.setState({ openRight: open})}>
+      <Drawer right={true} width={this.state.width} {...drawerProps} open={openRight} onChange={open => this.setState({ openRight: open})}>
         {val => {
           var per = val/ 300;
           return <div style={{ backgroundColor: `rgba(0, 184, 212, ${per})`, width: '100%', height: '100%' }} />;
@@ -61,10 +67,10 @@ export default class App extends Component {
       </nav>
       </div>
       <div className="options">
-        <form>
-          <p>
-            <input type="checkbox" id="relative_width" onChange={()=>this.setState({relativeWidth: !this.state.relativeWidth})}/>
-            <label htmlFor="relative_width">Relative width</label>
+        <form className="row">
+          <p className="col s4">
+            <label htmlFor="width">Set width</label>
+            <input id="width" type="text" onChange={this.setWidth} value={this.state.width} />
           </p>
         </form>
       </div>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -16,7 +16,7 @@ export default class App extends Component {
 
   setWidth = (e) => {
     this.setState({
-      width: Number(e.target.value) || e.target.value),
+      width: Number(e.target.value) || e.target.value,
     });
   }
   render() {

--- a/lib/drawer.jsx
+++ b/lib/drawer.jsx
@@ -211,7 +211,7 @@ export default class Drawer extends React.Component {
                 onPress={this.onPress.bind(this)}
                 onPressUp={this.onPressUp.bind(this)}
                 onPan={this.onPan.bind(this)}
-                direction={Hammer.DIRECTION_HORIZONTAL} //TODO: temp
+                vertical={false}
               >
                 <div className={className} style={computedStyle}>
                   {isFunction(children)

--- a/lib/drawer.jsx
+++ b/lib/drawer.jsx
@@ -26,7 +26,7 @@ export default class Drawer extends React.Component {
     overlayClassName: string, // additional overlay className
     config: array, // configuration of the react-motion animation
     open: bool, // states if the drawer is open
-    width: number, // width of the drawer
+    width: oneOfType([number, string]), // width of the drawer
     height: oneOfType([number, string]), // height of the drawer
     handleWidth: number, // width of the handle
     peakingWidth: number, // width that the drawer peaks on press
@@ -66,7 +66,7 @@ export default class Drawer extends React.Component {
   }
 
   state = {
-    currentState: "CLOSED"
+    currentState: "CLOSED",
   };
 
   isState(s) {
@@ -110,7 +110,8 @@ export default class Drawer extends React.Component {
   open() {
     const { onChange, width } = this.props;
     onChange(true);
-    return this.setState({ currentState: "OPEN", x: width });
+
+    return this.setState({ currentState: "OPEN", x: this.calculateWidth() });
   }
 
   isClosingDirection(direction) {
@@ -147,7 +148,8 @@ export default class Drawer extends React.Component {
     }
 
     const { currentState } = this.state;
-    const { right, peakingWidth, width, handleWidth } = this.props;
+    const { right, peakingWidth, handleWidth } = this.props;
+    const { width } = this.calculateWidth();
     const { clientX } = pointers[0];
 
     let x = right ? document.body.clientWidth - clientX : clientX;
@@ -172,6 +174,11 @@ export default class Drawer extends React.Component {
   onOverlayTap(e) {
     e.preventDefault();
     if (this.isOpen()) this.close();
+  }
+
+  calculateWidth(){
+    const width = this.props.width;
+    return /\D/.test(width) ? document.body.clientWidth * (width.match(/\d*/) / 100) : width;
   }
 
   render() {
@@ -204,9 +211,8 @@ export default class Drawer extends React.Component {
                 onPress={this.onPress.bind(this)}
                 onPressUp={this.onPressUp.bind(this)}
                 onPan={this.onPan.bind(this)}
-                vertical={false}
+                direction={Hammer.DIRECTION_HORIZONTAL} //TODO: temp
               >
-
                 <div className={className} style={computedStyle}>
                   {isFunction(children)
                     ? children(interpolated.myProp)

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -3,7 +3,6 @@ export default function(val, props) {
     zIndex,
     left,
     right,
-    width,
     height,
     handleWidth,
     overlayColor,
@@ -14,6 +13,11 @@ export default function(val, props) {
   if (typeof document !== "undefined") {
     clientWidth = document.body.clientWidth;
   }
+  let width = props.width;
+  if(/\D/.test(width)) width = document.body.clientWidth * (width.match(/\d*/) / 100);
+
+  console.info('val', val, 'offset', offset, 'width', width);
+
   const opacity = (val - offset) / width;
 
   if (right) val = width - val;

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -16,8 +16,6 @@ export default function(val, props) {
   let width = props.width;
   if(/\D/.test(width)) width = document.body.clientWidth * (width.match(/\d*/) / 100);
 
-  console.info('val', val, 'offset', offset, 'width', width);
-
   const opacity = (val - offset) / width;
 
   if (right) val = width - val;


### PR DESCRIPTION
Resolves #17

I figured `%` and `vw` would calculate to the same width considering the drawers live in the clientWidth, so I check for either.

Possible issues include not recalculating after window resize, causing some wonky stuff to happen with the drawer content. Not sure if this is an edge case or if this will be quite common and needs to be considered.