### PR TITLE
Fix document is not defined

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -9,13 +9,15 @@ export default function(val, props) {
     fadeOut,
     offset
   } = props;
+  
   let clientWidth = 1000;
+  let width = props.width;
+  
   if (typeof document !== "undefined") {
     clientWidth = document.body.clientWidth;
+    if (/\D/.test(width))
+      width = document.body.clientWidth * (width.match(/\d*/) / 100);
   }
-  let width = props.width;
-  if (/\D/.test(width))
-    width = document.body.clientWidth * (width.match(/\d*/) / 100);
 
   const opacity = (val - offset) / width;
 


### PR DESCRIPTION
Unhandled rejection ReferenceError: document is not defined
    at exports.default (/path/to/node_modules/react-motion-drawer/styles.js:24:33)

Faced an issue with this in another project, realized my mistake.

This fixes the ReferenceError issue. Don't see any other issues. With this change it's working in practice now.