### PR TITLE
Replacing deprecated React.PropTypes with standalone dependency 'prop-types'

### DIFF
--- a/lib/drawer.jsx
+++ b/lib/drawer.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Motion, spring } from "react-motion";
 import Hammer from "react-hammerjs";
 import assign from "1-liners/assign";
@@ -13,7 +14,7 @@ const {
   string,
   func,
   oneOfType
-} = React.PropTypes;
+} = PropTypes;
 
 export default class Drawer extends React.Component {
   static propTypes = {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "1-liners": "^0.4.0",
     "babel-preset-stage-0": "^6.22.0",
+    "prop-types": "^15.5.10",
     "react-hammerjs": "^0.5.0",
     "react-motion": "^0.4.7"
   }


### PR DESCRIPTION
In the next release of React, it's export 'PropTypes' will be deprecated.
PropTypes now has it's own package on npm, called 'prop-types'.