### PR TITLE
Made onPressUp look at noTouchClose

### DIFF
--- a/lib/drawer.jsx
+++ b/lib/drawer.jsx
@@ -119,6 +119,7 @@ export default class Drawer extends React.Component {
   };
 
   onPressUp = e => {
+    if (this.props.noTouchClose) return;
     e.preventDefault();
     this.close();
   };


### PR DESCRIPTION
Closing on long press of drawer is now controlled by `noTouchClose`. This was probably meant to be the desired behaviour.