### PR TITLE
Prevent crash when invoked with decimal width

### DIFF
--- a/lib/drawer.jsx
+++ b/lib/drawer.jsx
@@ -173,7 +173,7 @@ export default class Drawer extends React.Component {
 
   calculateWidth = () => {
     const width = this.props.width;
-    return /\D/.test(width)
+    return /\%/.test(width)
       ? document.body.clientWidth * (width.match(/\d*/) / 100)
       : width;
   };


### PR DESCRIPTION
Hello, We encountered an issue with this library because we were using it with non integer width and it gets caught in the \/D\.test regexp :)

All of it was resulting in having a "TypeError: e.match is not a function".

Therefore I thought this regexp should be more specific to relative width as it was it first aim and let the decimal values be used as width !